### PR TITLE
Add support for sample weighting configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONTAINER=deepform/deepform_learner:latest
 
 .PHONY: help
 help: ## Show this help dialog
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z/\._-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: test
 test: docker-build  ## Run all the unit tests for the project
@@ -43,8 +43,7 @@ docker-background: docker-stop docker-build ## Launch a docker container as a ba
 # data/training.parquet:
 # 	curl https://project-deepform.s3-us-west-1.amazonaws.com/training_data/training.parquet -o data/training.parquet
 
-# This shouldn't normally need to be run, but this downloads all the PDFs to local storage.
-data/pdfs: data/fcc-data-2020-labeled-manifest.csv
+data/pdfs: data/fcc-data-2020-labeled-manifest.csv ## Downloads all PDFs to local storage. Not usually necessary.
 	docker build -t $(CONTAINER) .
 	docker run --rm --mount type=bind,source=$(CURDIR)/data,target=/data $(CONTAINER) python -c "import pandas as pd; print('\n'.join(pd.read_csv('data/fcc-data-2020-labeled-manifest.csv').URL))" | xargs wget -P data/pdfs
 
@@ -53,7 +52,8 @@ data/pdfs: data/fcc-data-2020-labeled-manifest.csv
 # 	docker build -t $(CONTAINER) .
 # 	docker run --rm --mount type=bind,source=$(CURDIR)/data,target=/data $(CONTAINER) python -m deepform.data.tokenize_pdfs
 
-data/tokenized: data/tokenized.tar.gz  ## Get document tokens from S3
+data/tokenized:  ## Get document tokens from S3
+#data/tokenized: data/tokenized.tar.gz  ## Get document tokens from S3
 	curl https://project-deepform.s3-us-west-1.amazonaws.com/training_data/token_data.tar.gz -o data/tokenized.tar.gz
 	mkdir -p data/tokenized
 	tar xf data/tokenized.tar.gz -C data/tokenized

--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -79,6 +79,19 @@ penalize_missed:
 learning_rate:
   value: 0.001
 
+sample_weighting:
+  desc: parameters for weighting samples during training by a column value
+  value:
+    column: year
+    values:
+      - value: 2012
+        weight: 0.5
+      - value: 2016
+        weight: 0.7
+      - value: 2020
+        weight: 1.0
+
+
 # These do not affect the training but control various setup and reporting
 render_results_size:
   desc: log this many PDF images on last epoch

--- a/deepform/combine_manifests.py
+++ b/deepform/combine_manifests.py
@@ -1,36 +1,97 @@
-import pandas as pd
-import numpy as np
 import os
+
+import numpy as np
+import pandas as pd
+
 from deepform.common import DATA_DIR
 
-if os.path.exists(DATA_DIR/"3_year_manifest.csv"):
-  os.remove(DATA_DIR/"3_year_manifest.csv")
+if os.path.exists(DATA_DIR / "3_year_manifest.csv"):
+    os.remove(DATA_DIR / "3_year_manifest.csv")
 
 
-df12 = pd.read_csv(DATA_DIR/"ftf-all-filings.tsv", sep='\t')
-df12.insert(0, 'serial_num', np.nan)
-df12.insert(0, 'flight_from', np.nan)
-df12.insert(0, 'flight_to', np.nan)
-df12.insert(0, 'Issues', np.nan)
-df12_new = df12.filter(['dc_slug', 'serial_num','gross_amount','committee', 'flight_from', 'flight_to', 'Issues' ], axis=1)
-df12_new.insert(0, 'year', '2012')
-df12_new.columns = ['year', 'slug', 'serial_num', 'gross_amount', 'advertiser', 'flight_from', 'flight_to', 'Issues']
+df12 = pd.read_csv(DATA_DIR / "ftf-all-filings.tsv", sep="\t")
+df12.insert(0, "serial_num", np.nan)
+df12.insert(0, "flight_from", np.nan)
+df12.insert(0, "flight_to", np.nan)
+df12.insert(0, "Issues", np.nan)
+df12_new = df12.filter(
+    [
+        "dc_slug",
+        "serial_num",
+        "gross_amount",
+        "committee",
+        "flight_from",
+        "flight_to",
+        "Issues",
+    ],
+    axis=1,
+)
+df12_new.insert(0, "year", "2012")
+df12_new.columns = [
+    "year",
+    "slug",
+    "serial_num",
+    "gross_amount",
+    "advertiser",
+    "flight_from",
+    "flight_to",
+    "Issues",
+]
 
-df14 = pd.read_csv(DATA_DIR/"2014-orders.tsv", sep='\t')
-df14.insert(0, 'gross_amount', np.nan)
-df14.insert(0, 'Issues', np.nan)
-df14_new = df14.filter(['id', 'order_revision','gross_amount','advertiser', 'flight_from', 'flight_to', 'Issues' ], axis=1)
-df14_new.insert(0, 'year', '2014')
-df14_new.columns = ['year', 'slug', 'serial_num', 'gross_amount', 'advertiser', 'flight_from', 'flight_to', 'Issues']
+df14 = pd.read_csv(DATA_DIR / "2014-orders.tsv", sep="\t")
+df14.insert(0, "gross_amount", np.nan)
+df14.insert(0, "Issues", np.nan)
+df14_new = df14.filter(
+    [
+        "id",
+        "order_revision",
+        "gross_amount",
+        "advertiser",
+        "flight_from",
+        "flight_to",
+        "Issues",
+    ],
+    axis=1,
+)
+df14_new.insert(0, "year", "2014")
+df14_new.columns = [
+    "year",
+    "slug",
+    "serial_num",
+    "gross_amount",
+    "advertiser",
+    "flight_from",
+    "flight_to",
+    "Issues",
+]
 
-df20 = pd.read_csv(DATA_DIR/"fcc-data-2020-sample-updated.csv")
-df20_new = df20.filter(['full_file_name', 'serial_num','gross_amount','advertiser', 'flight_from', 'flight_to', "Issues ('', Type, or Token)" ], axis=1)
-df20_new.insert(0, 'year', '2020')
-df20_new.columns = ['year', 'slug', 'serial_num', 'gross_amount', 'advertiser', 'flight_from', 'flight_to', 'Issues']
+df20 = pd.read_csv(DATA_DIR / "fcc-data-2020-sample-updated.csv")
+df20_new = df20.filter(
+    [
+        "full_file_name",
+        "serial_num",
+        "gross_amount",
+        "advertiser",
+        "flight_from",
+        "flight_to",
+        "Issues ('', Type, or Token)",
+    ],
+    axis=1,
+)
+df20_new.insert(0, "year", "2020")
+df20_new.columns = [
+    "year",
+    "slug",
+    "serial_num",
+    "gross_amount",
+    "advertiser",
+    "flight_from",
+    "flight_to",
+    "Issues",
+]
 
 df = pd.concat([df12_new, df14_new, df20_new])
 
 df.set_index(["year", "slug"]).count(level="year")
 
-df.to_csv(DATA_DIR/"3_year_manifest.csv")
-
+df.to_csv(DATA_DIR / "3_year_manifest.csv")

--- a/deepform/data/add_features.py
+++ b/deepform/data/add_features.py
@@ -36,6 +36,8 @@ class TokenType(Enum):
     GROSS_AMOUNT = auto()
 
 
+YEAR_COL = "year"
+
 LABEL_COLS = {
     # Each label column, and the match function that it uses.
     "contract_num": default_similarity,
@@ -54,6 +56,7 @@ def extend_and_write_docs(source_dir, manifest, pq_index, out_path):
     jobqueue = []
     for row in manifest.itertuples():
         slug = row.file_id
+        year = row.year if hasattr(row, "year") else None
         if slug not in token_files:
             logging.error(f"No token file for {slug}")
             continue
@@ -67,6 +70,7 @@ def extend_and_write_docs(source_dir, manifest, pq_index, out_path):
                 "token_file": token_files[slug],
                 "dest_file": out_path / f"{slug}.parquet",
                 "labels": labels,
+                "year": year,
             }
         )
 
@@ -97,7 +101,7 @@ def pq_index_and_dir(pq_index, pq_path=None):
     return pq_index, pq_path
 
 
-def process_document_tokens(token_file, dest_file, labels):
+def process_document_tokens(token_file, dest_file, labels, year=None):
     """Filter out short tokens, add computed features, and return index info."""
     slug = token_file.stem
     doc = pd.read_parquet(token_file)

--- a/deepform/document.py
+++ b/deepform/document.py
@@ -55,6 +55,7 @@ class Window:
 @dataclass(frozen=True)
 class Document:
     slug: str
+    year: int
     # tokens, features, and labels are all aligned with the same indices.
     tokens: pd.DataFrame
     features: np.ndarray
@@ -126,7 +127,7 @@ class Document:
         return "\n".join([title, predicted, body.to_string()])
 
     @staticmethod
-    def from_parquet(slug, label_values, pq_path, config):
+    def from_parquet(slug, label_values, pq_path, config, year=None):
         """Load precomputed features from a parquet file and apply a config."""
         df = pd.read_parquet(pq_path)
 
@@ -155,6 +156,7 @@ class Document:
 
         return Document(
             slug=slug,
+            year=year,
             tokens=df[TOKEN_COLS],
             features=df[FEATURE_COLS].to_numpy(dtype=float),
             labels=labels.to_numpy(dtype=int),

--- a/deepform/document_store.py
+++ b/deepform/document_store.py
@@ -65,8 +65,10 @@ class DocumentStore:
         labels = doc_index[LABEL_COLS.keys()]
         years = doc_index[YEAR_COL]
         docs = np.array(
-            [slug_to_doc(slug, labels.loc[slug], year=year) for slug, year
-             in zip(doc_index.index, years)]
+            [
+                slug_to_doc(slug, labels.loc[slug], year=year)
+                for slug, year in zip(doc_index.index, years)
+            ]
         )
         docs = docs[docs != None]  # noqa: E711
 

--- a/deepform/model.py
+++ b/deepform/model.py
@@ -39,11 +39,7 @@ def one_window(dataset, config, sample_key_label=None):
         window.features = window.features[shuffle]
         window.labels = window.labels[shuffle]
 
-    if sample_key_label:
-        sample_key = document.label_values.get(sample_key_label)
-    else:
-        sample_key = None
-
+    sample_key = document.year if sample_key_label else None
     return window, sample_key
 
 
@@ -53,8 +49,8 @@ def windowed_generator(dataset, config):
     batch_labels = np.zeros((config.batch_size, config.window_len))
 
     sample_weighting = sample_weights(config)
-    batch_sample_weights =
-        np.ones((config.batch_size, config.window_len)) if sample_weighting else None
+    batch_sample_weights = np.ones((config.batch_size, config.window_len)) \
+        if sample_weighting else None
 
     while True:
         for i in range(config.batch_size):

--- a/deepform/model.py
+++ b/deepform/model.py
@@ -21,10 +21,9 @@ from deepform.util import git_short_hash
 
 
 def sample_weights(config):
-    weight_config = config.get('sample_weights')
+    weight_config = config.get("sample_weights")
     if weight_config:
-        return {weight['value']: weight['weight']
-                for weight in weight_config['values']}
+        return {weight["value"]: weight["weight"] for weight in weight_config["values"]}
     else:
         return None
 
@@ -49,8 +48,9 @@ def windowed_generator(dataset, config):
     batch_labels = np.zeros((config.batch_size, config.window_len))
 
     sample_weighting = sample_weights(config)
-    batch_sample_weights = np.ones((config.batch_size, config.window_len)) \
-        if sample_weighting else None
+    batch_sample_weights = (
+        np.ones((config.batch_size, config.window_len)) if sample_weighting else None
+    )
 
     while True:
         for i in range(config.batch_size):

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,7 +238,6 @@ version = "7.1.2"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "python_version >= \"3.3\" and sys_platform == \"win32\" or sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -255,6 +254,14 @@ version = "5.0.0"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
+
+[[package]]
+category = "dev"
+description = "A small Python package to hide or show the terminal cursor"
+name = "cursor"
+optional = false
+python-versions = "*"
+version = "1.3.4"
 
 [[package]]
 category = "dev"
@@ -539,6 +546,25 @@ version = "2.10.0"
 [package.dependencies]
 numpy = ">=1.7"
 six = "*"
+
+[[package]]
+category = "dev"
+description = "Beautiful terminal spinners in Python"
+name = "halo"
+optional = false
+python-versions = "*"
+version = "0.0.29"
+
+[package.dependencies]
+colorama = ">=0.3.9"
+cursor = ">=1.2.0"
+log-symbols = ">=0.0.14"
+six = ">=1.12.0"
+spinners = ">=0.0.24"
+termcolor = ">=1.1.0"
+
+[package.extras]
+ipython = ["IPython (5.7.0)", "ipywidgets (7.1.0)"]
 
 [[package]]
 category = "main"
@@ -878,6 +904,17 @@ python-versions = "*"
 version = "0.2.0"
 
 [[package]]
+category = "dev"
+description = "Colored symbols for various log levels for Python"
+name = "log-symbols"
+optional = false
+python-versions = "*"
+version = "0.0.14"
+
+[package.dependencies]
+colorama = ">=0.3.9"
+
+[[package]]
 category = "main"
 description = "LZ4 Bindings for Python"
 name = "lz4"
@@ -1112,8 +1149,24 @@ version = "1.4.2"
 
 [[package]]
 category = "dev"
+description = "Easy install parquet-tools"
+name = "parquet-tools"
+optional = false
+python-versions = ">=3.8,<4.0"
+version = "0.2.4"
+
+[package.dependencies]
+boto3 = ">=1.13.25,<2.0.0"
+colorama = ">=0.4.3,<0.5.0"
+halo = ">=0.0.29,<0.0.30"
+pandas = ">=1.0.4,<2.0.0"
+pyarrow = ">=0.17.1,<0.18.0"
+tabulate = ">=0.8.7,<0.9.0"
+thrift = ">=0.13.0,<0.14.0"
+
+[[package]]
+category = "dev"
 description = "A Python Parser"
-marker = "python_version >= \"3.3\""
 name = "parso"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -1306,7 +1359,7 @@ test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 [[package]]
 category = "dev"
 description = "Run a subprocess in a pseudo terminal"
-marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or os_name != \"nt\""
+marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\" or os_name != \"nt\" or python_version >= \"3.3\" and sys_platform != \"win32\" and (python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\")"
 name = "ptyprocess"
 optional = false
 python-versions = "*"
@@ -1683,6 +1736,14 @@ python-versions = "*"
 version = "2.2.2"
 
 [[package]]
+category = "dev"
+description = "Spinners for terminals"
+name = "spinners"
+optional = false
+python-versions = "*"
+version = "0.0.24"
+
+[[package]]
 category = "main"
 description = "Database Abstraction Library"
 name = "sqlalchemy"
@@ -1709,6 +1770,17 @@ name = "subprocess32"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
 version = "3.5.4"
+
+[[package]]
+category = "dev"
+description = "Pretty-print tabular data"
+name = "tabulate"
+optional = false
+python-versions = "*"
+version = "0.8.7"
+
+[package.extras]
+widechars = ["wcwidth"]
 
 [[package]]
 category = "main"
@@ -1818,6 +1890,22 @@ name = "text-unidecode"
 optional = false
 python-versions = "*"
 version = "1.3"
+
+[[package]]
+category = "dev"
+description = "Python bindings for the Apache Thrift RPC system"
+name = "thrift"
+optional = false
+python-versions = "*"
+version = "0.13.0"
+
+[package.dependencies]
+six = ">=1.7.2"
+
+[package.extras]
+all = ["tornado (>=4.0)", "twisted"]
+tornado = ["tornado (>=4.0)"]
+twisted = ["twisted"]
 
 [[package]]
 category = "dev"
@@ -2032,7 +2120,7 @@ python-versions = "*"
 version = "1.12.1"
 
 [metadata]
-content-hash = "b036d6e2c9e7a1c0fa141eeb8033472056aa154d0d2ed0e147498c85e332ec23"
+content-hash = "cf82bd55344b5e36334181923aad1661f25650365ec8106670c3d52aac3324b2"
 lock-version = "1.0"
 python-versions = "^3.8.1"
 
@@ -2166,6 +2254,9 @@ colorama = [
 configparser = [
     {file = "configparser-5.0.0-py3-none-any.whl", hash = "sha256:cffc044844040c7ce04e9acd1838b5f2e5fa3170182f6fda4d2ea8b0099dbadd"},
     {file = "configparser-5.0.0.tar.gz", hash = "sha256:2ca44140ee259b5e3d8aaf47c79c36a7ab0d5e94d70bd4105c03ede7a20ea5a1"},
+]
+cursor = [
+    {file = "cursor-1.3.4.tar.gz", hash = "sha256:33f279a17789c04efd27a92501a0dad62bb011f8a4cdff93867c798d26508940"},
 ]
 cycler = [
     {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
@@ -2323,6 +2414,10 @@ h5py = [
     {file = "h5py-2.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:769e141512b54dee14ec76ed354fcacfc7d97fea5a7646b709f7400cf1838630"},
     {file = "h5py-2.10.0.tar.gz", hash = "sha256:84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d"},
 ]
+halo = [
+    {file = "halo-0.0.29-py3-none-any.whl", hash = "sha256:67996649083229a9b7a93fe7c871c97d40bd2f1a988540eccf948a6b1844f644"},
+    {file = "halo-0.0.29.tar.gz", hash = "sha256:a8aeb0164e269d7c96fb7444b2a4caaa09b8989fa0c85e6a26e8b2c6d1af3b9d"},
+]
 humanize = [
     {file = "humanize-2.5.0-py3-none-any.whl", hash = "sha256:89062c6db8601693b7d223443d0d7529aa9577df43a1387ddd4b9c273abb4a51"},
     {file = "humanize-2.5.0.tar.gz", hash = "sha256:8a68bd9bccb899fd9bfb1e6d96c1e84e4475551cc9a5b5bdbd69b9b1cfd19c80"},
@@ -2408,16 +2503,19 @@ kiwisolver = [
     {file = "kiwisolver-1.2.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74"},
     {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8"},
     {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"},
+    {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:be046da49fbc3aa9491cc7296db7e8d27bcf0c3d5d1a40259c10471b014e4e0c"},
     {file = "kiwisolver-1.2.0-cp36-none-win32.whl", hash = "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b"},
     {file = "kiwisolver-1.2.0-cp36-none-win_amd64.whl", hash = "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec"},
+    {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:63f55f490b958b6299e4e5bdac66ac988c3d11b7fafa522800359075d4fa56d1"},
     {file = "kiwisolver-1.2.0-cp37-none-win32.whl", hash = "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c"},
     {file = "kiwisolver-1.2.0-cp37-none-win_amd64.whl", hash = "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1"},
     {file = "kiwisolver-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113"},
     {file = "kiwisolver-1.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e"},
     {file = "kiwisolver-1.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657"},
+    {file = "kiwisolver-1.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:38d05c9ecb24eee1246391820ed7137ac42a50209c203c908154782fced90e44"},
     {file = "kiwisolver-1.2.0-cp38-none-win32.whl", hash = "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf"},
     {file = "kiwisolver-1.2.0-cp38-none-win_amd64.whl", hash = "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd"},
     {file = "kiwisolver-1.2.0.tar.gz", hash = "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f"},
@@ -2447,6 +2545,10 @@ lazy-object-proxy = [
 ]
 locket = [
     {file = "locket-0.2.0.tar.gz", hash = "sha256:1fee63c1153db602b50154684f5725564e63a0f6d09366a1cb13dffcec179fb4"},
+]
+log-symbols = [
+    {file = "log_symbols-0.0.14-py3-none-any.whl", hash = "sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca"},
+    {file = "log_symbols-0.0.14.tar.gz", hash = "sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556"},
 ]
 lz4 = [
     {file = "lz4-3.1.0-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:17f9763619059eb08783ef2e106217d80c3022bb1c20f3199ac374c1daf54d9f"},
@@ -2627,6 +2729,10 @@ pandas = [
 pandocfilters = [
     {file = "pandocfilters-1.4.2.tar.gz", hash = "sha256:b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9"},
 ]
+parquet-tools = [
+    {file = "parquet_tools-0.2.4-py3-none-any.whl", hash = "sha256:2e43700c1de2427076f7a2d781d281f27e54d51a0e57519ef348b8b4c9a038ec"},
+    {file = "parquet_tools-0.2.4.tar.gz", hash = "sha256:3ebfb63e51b38176dd623e0b7a6b06c3e2766d2b60820edec4c2858e1864e557"},
+]
 parso = [
     {file = "parso-0.7.1-py2.py3-none-any.whl", hash = "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea"},
     {file = "parso-0.7.1.tar.gz", hash = "sha256:caba44724b994a8a5e086460bb212abc5a8bc46951bf4a9a1210745953622eb9"},
@@ -2682,6 +2788,8 @@ pillow = [
     {file = "Pillow-7.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8"},
     {file = "Pillow-7.2.0-cp38-cp38-win32.whl", hash = "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f"},
     {file = "Pillow-7.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6"},
+    {file = "Pillow-7.2.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:9c87ef410a58dd54b92424ffd7e28fd2ec65d2f7fc02b76f5e9b2067e355ebf6"},
+    {file = "Pillow-7.2.0-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:e901964262a56d9ea3c2693df68bc9860b8bdda2b04768821e4c44ae797de117"},
     {file = "Pillow-7.2.0-pp36-pypy36_pp73-win32.whl", hash = "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d"},
     {file = "Pillow-7.2.0.tar.gz", hash = "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626"},
 ]
@@ -3036,6 +3144,10 @@ sortedcontainers = [
     {file = "sortedcontainers-2.2.2-py2.py3-none-any.whl", hash = "sha256:c633ebde8580f241f274c1f8994a665c0e54a17724fecd0cae2f079e09c36d3f"},
     {file = "sortedcontainers-2.2.2.tar.gz", hash = "sha256:4e73a757831fc3ca4de2859c422564239a31d8213d09a2a666e375807034d2ba"},
 ]
+spinners = [
+    {file = "spinners-0.0.24-py3-none-any.whl", hash = "sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98"},
+    {file = "spinners-0.0.24.tar.gz", hash = "sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f"},
+]
 sqlalchemy = [
     {file = "SQLAlchemy-1.3.18-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:f11c2437fb5f812d020932119ba02d9e2bc29a6eca01a055233a8b449e3e1e7d"},
     {file = "SQLAlchemy-1.3.18-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:0ec575db1b54909750332c2e335c2bb11257883914a03bc5a3306a4488ecc772"},
@@ -3068,7 +3180,12 @@ sqlalchemy = [
 ]
 subprocess32 = [
     {file = "subprocess32-3.5.4-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:88e37c1aac5388df41cc8a8456bb49ebffd321a3ad4d70358e3518176de3a56b"},
+    {file = "subprocess32-3.5.4-cp27-cp27mu-manylinux2014_x86_64.whl", hash = "sha256:e45d985aef903c5b7444d34350b05da91a9e0ea015415ab45a21212786c649d0"},
     {file = "subprocess32-3.5.4.tar.gz", hash = "sha256:eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d"},
+]
+tabulate = [
+    {file = "tabulate-0.8.7-py3-none-any.whl", hash = "sha256:ac64cb76d53b1231d364babcd72abbb16855adac7de6665122f97b593f1eb2ba"},
+    {file = "tabulate-0.8.7.tar.gz", hash = "sha256:db2723a20d04bcda8522165c73eea7c300eda74e0ce852d9022e0159d7895007"},
 ]
 tensorboard = [
     {file = "tensorboard-2.3.0-py3-none-any.whl", hash = "sha256:d34609ed83ff01dd5b49ef81031cfc9c166bba0dabd60197024f14df5e8eae5e"},
@@ -3107,6 +3224,9 @@ testpath = [
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
     {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+thrift = [
+    {file = "thrift-0.13.0.tar.gz", hash = "sha256:9af1c86bf73433afc6010ed376a6c6aca2b54099cc0d61895f640870a9ae7d89"},
 ]
 toml = [
     {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pytest = "^5.4.3"
 hypothesis = "^5.24.0"
 faker = "^4.1.1"
 babel = "^2.8.0"
+parquet-tools = "^0.2.4"
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
*Status*: I'm not positive this works because I don't have the data plumbed with a usable label_value for this, but I'm putting it up now for visibility and to get some preliminary review on the change.

We would like to have the capability to bias training towards more recent datasets. To that end, we can make use of the sample weighting support in Tensorflow/Keras and assign weight to samples according to some configured rule.

[tf.keras.Model#fit](https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit)
> A generator or keras.utils.Sequence returning (inputs, targets) or (inputs, targets, sample_weights). A more detailed description of unpacking behavior for iterator types (Dataset, generator, Sequence) is given below.

- `sample_weighting` config value added with a label and arbitrary example weight mappings for illustration
- _Makefile_ improvements which I happened to make in the course of working on this. The previously added help string target missed targets that contained `/` or `.` characters.
- functions in `Model.py` updated to generate sample weights if so configured