### PR TITLE
Add support for uploading and downloading model artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,9 @@ sweep: data/doc_index.parquet data/token_frequency.csv .env docker-build ## Run 
 	docker run --rm --env-file=.env \
 	--mount type=bind,source=$(CURDIR)/data,target=/data $(CONTAINER) \
 	./init_sweep.sh
+
+VERSION='stable'
+download: ## Download a model for use with the inference script
+	docker run --rm --env-file=.env \
+	--mount type=bind,source=$(CURDIR)/data,target=/data $(CONTAINER) \
+	python -m deepform.artifacts --version $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ sweep: data/doc_index.parquet data/token_frequency.csv .env docker-build ## Run 
 	./init_sweep.sh
 
 VERSION='stable'
-download: ## Download a model for use with the inference script
+download-model: ## Download a model for use with the inference script
 	docker run --rm --env-file=.env \
 	--mount type=bind,source=$(CURDIR)/data,target=/data $(CONTAINER) \
 	python -m deepform.artifacts --version $(VERSION)

--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -98,6 +98,9 @@ save_model:
 model_path:
   desc: path to save the model (if not set, autogenerate)
   value: 0
+model_artifact_name:
+  desc: used to identify saved models in Weights & Biases
+  value: deepform-model
 use_wandb:
   desc: report run to wandb and store annotations
   value: 1

--- a/deepform/artifacts.py
+++ b/deepform/artifacts.py
@@ -1,0 +1,29 @@
+import argparse
+
+import wandb
+
+from deepform.common import MODEL_DIR, WANDB_ENTITY, WANDB_PROJECT
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="download a model stored in W&B")
+    parser.add_argument(
+        "-v",
+        "--version",
+        dest="version",
+        help="model version to download",
+        default="latest",
+    )
+    args = parser.parse_args()
+
+    run = wandb.init(
+        project="model-download",
+        entity=WANDB_ENTITY,
+        job_type="ps",
+        allow_val_change=True,
+    )
+    config = run.config
+    model_name = config.model_artifact_name
+    artifact_name = f"{WANDB_ENTITY}/{WANDB_PROJECT}/{model_name}:{args.version}"
+    artifact = run.use_artifact(artifact_name, type="model")
+    artifact_alias = artifact.metadata.get("name") or "unknown"
+    artifact.download(root=(MODEL_DIR / artifact_alias))

--- a/deepform/common.py
+++ b/deepform/common.py
@@ -11,3 +11,6 @@ LABELED_DIR = DATA_DIR / "labeled"
 TRAINING_DIR = DATA_DIR / "training"
 TRAINING_INDEX = TRAINING_DIR.parent / "doc_index.parquet"
 MODEL_DIR = DATA_DIR / "models"
+
+WANDB_PROJECT = "extract_total"
+WANDB_ENTITY = "deepform"

--- a/deepform/model.py
+++ b/deepform/model.py
@@ -142,3 +142,4 @@ def save_model(model, config):
     basename = Path(config.model_path) or default_model_name(config.window_len)
     basename.parent.mkdir(parents=True, exist_ok=True)
     model.save(basename)
+    return basename

--- a/deepform/model.py
+++ b/deepform/model.py
@@ -139,7 +139,11 @@ def load_model(model_file=None):
 
 
 def save_model(model, config):
-    basename = Path(config.model_path) or default_model_name(config.window_len)
+    basename = (
+        Path(config.model_path)
+        if config.model_path
+        else default_model_name(config.window_len)
+    )
     basename.parent.mkdir(parents=True, exist_ok=True)
     model.save(basename)
     return basename

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -124,7 +124,7 @@ class DocAccCallback(K.callbacks.Callback):
         wandb.log({self.logname: acc_str})
 
 
-def main(config):
+def main(run, config):
     config.name = config_desc(config)
     if config.use_wandb:
         run.save()
@@ -157,7 +157,12 @@ def main(config):
     )
 
     if config.save_model:
-        save_model(model, config)
+        model_filepath = save_model(model, config)
+        artifact = wandb.Artifact("deepform-model", type="model")
+        artifact.add_dir(
+            str(model_filepath)
+        )  # TODO: check that this is necessary? What does wandb api expect here?
+        run.log_artifact(artifact)
 
 
 if __name__ == "__main__":
@@ -188,4 +193,4 @@ if __name__ == "__main__":
 
     logger.setLevel(config.log_level)
 
-    main(config)
+    main(run, config)

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -16,7 +16,7 @@ import wandb
 from tensorflow import keras as K
 from wandb.keras import WandbCallback
 
-from deepform.common import LOG_DIR, TRAINING_INDEX
+from deepform.common import LOG_DIR, TRAINING_INDEX, WANDB_ENTITY, WANDB_PROJECT
 from deepform.data.add_features import LABEL_COLS
 from deepform.document_store import DocumentStore
 from deepform.logger import logger
@@ -124,7 +124,7 @@ class DocAccCallback(K.callbacks.Callback):
         wandb.log({self.logname: acc_str})
 
 
-def main(run, config):
+def main(config):
     config.name = config_desc(config)
     if config.use_wandb:
         run.save()
@@ -158,16 +158,24 @@ def main(run, config):
 
     if config.save_model:
         model_filepath = save_model(model, config)
-        artifact = wandb.Artifact("deepform-model", type="model")
+        alias = model_filepath.name
+        artifact = wandb.Artifact(
+            "deepform-model", type="model", metadata={"name": alias}
+        )
         artifact.add_dir(
             str(model_filepath)
         )  # TODO: check that this is necessary? What does wandb api expect here?
-        run.log_artifact(artifact)
+        run.log_artifact(artifact, aliases=["latest", alias])
 
 
 if __name__ == "__main__":
     # First read in the initial configuration.
-    run = wandb.init(project="extract_total", entity="deepform", allow_val_change=True)
+    run = wandb.init(
+        project=WANDB_PROJECT,
+        entity=WANDB_ENTITY,
+        job_type="train",
+        allow_val_change=True,
+    )
     config = run.config
 
     # Then override it with any parameters passed along the command line.
@@ -193,4 +201,4 @@ if __name__ == "__main__":
 
     logger.setLevel(config.log_level)
 
-    main(run, config)
+    main(config)


### PR DESCRIPTION

## Changes:

- `train.py` saves its model directory as a W&B artifact
- `artifacts.py` downloads a specified model version, defaulting to _latest_
- `make download` provides easy shorthand for running `artifacts.py`, defaulting to version _stable_


## Expected Workflow:

1. training runs automatically upload their models to W&B
2. If and when we determine a model is the latest good version, we tag it as _stable_ in the W&B UI
3. Users of deepform with W&B access can download the latest model instead of retraining, which will greatly expedite and ease downstream development.

Example `make` usage:

```
$ make VERSION=latest download
```


## To Do soon:
- Upload an artifact with that _stable_ alias (I can do this with one of the recently trained models from @jstray )