### PR TITLE
benchmark-compatibility improvements

### DIFF
--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -10,7 +10,7 @@ len_train:
 val_split:
   value: 0.2
 random_seed:
-  value: 42
+  value: 23
 
 # sweeps suggest these are reasonable hyperparameter defaults
 window_len:

--- a/config-defaults.yaml
+++ b/config-defaults.yaml
@@ -4,8 +4,13 @@ len_train:
   dec: number of documents to use (training + validation)
   value: 15000
 
+# training dataset settings required for benchmark submissions
+# do not change these if you'd like a pure comparison to the
+# other benchmark submissions
 val_split:
   value: 0.2
+random_seed:
+  value: 42
 
 # sweeps suggest these are reasonable hyperparameter defaults
 window_len:

--- a/deepform/artifacts.py
+++ b/deepform/artifacts.py
@@ -2,7 +2,7 @@ import argparse
 
 import wandb
 
-from deepform.common import MODEL_DIR, WANDB_ENTITY, WANDB_PROJECT
+from deepform.common import MODEL_DIR, WANDB_PROJECT
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="download a model stored in W&B")
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     )
     config = run.config
     model_name = config.model_artifact_name
-    artifact_name = f"{WANDB_ENTITY}/{WANDB_PROJECT}/{model_name}:{args.version}"
+    artifact_name = f"{WANDB_PROJECT}/{model_name}:{args.version}"
     artifact = run.use_artifact(artifact_name, type="model")
     artifact_alias = artifact.metadata.get("name") or "unknown"
     artifact.download(root=(MODEL_DIR / artifact_alias))

--- a/deepform/artifacts.py
+++ b/deepform/artifacts.py
@@ -17,7 +17,6 @@ if __name__ == "__main__":
 
     run = wandb.init(
         project="model-download",
-        entity=WANDB_ENTITY,
         job_type="ps",
         allow_val_change=True,
     )

--- a/deepform/common.py
+++ b/deepform/common.py
@@ -12,5 +12,4 @@ TRAINING_DIR = DATA_DIR / "training"
 TRAINING_INDEX = TRAINING_DIR.parent / "doc_index.parquet"
 MODEL_DIR = DATA_DIR / "models"
 
-WANDB_PROJECT = "extract_total"
-WANDB_ENTITY = "deepform"
+WANDB_PROJECT = "deepform_v1"

--- a/deepform/pdfs.py
+++ b/deepform/pdfs.py
@@ -89,7 +89,7 @@ def log_wandb_pdfs(doc, doc_log, all_scores):
             pred_bboxes.append(
                 wandb_bbox(
                     token,
-                    rel_score[token.Index],
+                    score,
                     class_ids_by_field[curr_field],
                     im,
                 )
@@ -108,11 +108,7 @@ def log_wandb_pdfs(doc, doc_log, all_scores):
             "class_labels": class_id_to_label,
         },
     }
-    wandb.log(
-        {
-            f"pdf/{fname.name}:{pagenum}": wandb.Image(im.annotated, boxes=boxes)
-        }
-    )
+    wandb.log({f"pdf/{fname.name}:{pagenum}": wandb.Image(im.annotated, boxes=boxes)})
 
 
 def log_pdf(doc, score, scores, predict_text, answer_text):

--- a/deepform/pdfs.py
+++ b/deepform/pdfs.py
@@ -110,10 +110,7 @@ def log_wandb_pdfs(doc, doc_log, all_scores):
     }
     wandb.log(
         {
-            "pdf/"
-            + fname.name
-            + ":"
-            + str(pagenum): wandb.Image(im.annotated, boxes=boxes)
+            f"pdf/{fname.name}:{pagenum}": wandb.Image(im.annotated, boxes=boxes)
         }
     )
 

--- a/deepform/pdfs.py
+++ b/deepform/pdfs.py
@@ -57,7 +57,7 @@ def log_wandb_pdfs(doc, doc_log, all_scores, draw_wandb_boxes=False):
         logger.warn(f"Cannot open pdf {fname}")
         return
 
-    print(f"Rendering output for {fname}")
+    logger.info(f"Rendering output for {fname}")
 
     # Get the correct answers: find the indices of the token(s) labeled 1
     target_idx = [idx for (idx, val) in enumerate(doc.labels) if val == 1]

--- a/deepform/pdfs.py
+++ b/deepform/pdfs.py
@@ -54,7 +54,7 @@ def log_wandb_pdfs(doc, doc_log, all_scores, draw_wandb_boxes=False):
     except Exception:
         # If the file's not there, that's fine -- we use available PDFs to
         # define what to see
-        print(f"Cannot open pdf {fname}")
+        logger.warn(f"Cannot open pdf {fname}")
         return
 
     print(f"Rendering output for {fname}")

--- a/deepform/pdfs.py
+++ b/deepform/pdfs.py
@@ -46,6 +46,72 @@ def download_from_remote(local_path):
         logger.error(f"Unable to retrieve {s3_key} from s3://{S3_BUCKET}")
         raise
 
+def log_pdfs(doc, doc_log, all_scores):
+    fname = get_pdf_path(doc.slug)
+    try:
+        pdf = pdfplumber.open(fname)
+    except Exception:
+        # If the file's not there, that's fine -- we use available PDFs to
+        # define what to see
+        print(f"Cannot open pdf {fname}")
+        return
+
+    print(f"Rendering output for {fname}")
+
+    # Get the correct answers: find the indices of the token(s) labelled 1
+    target_idx = [idx for (idx, val) in enumerate(doc.labels) if val == 1]
+
+    # Draw the machine output: get a score for each token
+    page_images = []
+    for pagenum, page in enumerate(pdf.pages):
+        im = page.to_image(resolution=300)
+
+        # training data has 0..1 for page range (see create-training-data.py)
+        num_pages = len(pdf.pages)
+        if num_pages > 1:
+            current_page = pagenum / float(num_pages - 1)
+        else:
+            current_page = 0.0
+
+        # Draw guesses
+        # loop over all predictions
+        
+        field_colors = {"gross_amount" : "magenta", "flight_to" : "red", "flight_from" : "green", "advertiser" : "blue", "contract_num" : "orange"} 
+        for i, score in enumerate(doc_log["score"]):
+            rel_score = all_scores[:, i] / score
+            page_match = np.isclose(doc.tokens["page"], current_page)
+            fc = field_colors[doc_log["field"][i]]
+            for token in doc.tokens[page_match & (rel_score > 0.9)].itertuples():
+                if rel_score[token.Index] == 1:
+                    w = 8
+                    #s = "magenta"
+                elif rel_score[token.Index] >= 0.75:
+                    w = 4
+                    #s = "red"
+                else:
+                    w = 1
+                    #s = "red"
+                im.draw_rect(docrow_to_bbox(token), stroke=fc, stroke_width=w, fill=None)
+
+            # Draw target tokens
+            target_toks = [
+                doc.tokens.iloc[i]
+                for i in target_idx
+                if np.isclose(doc.tokens.iloc[i]["page"], current_page)
+            ]
+            rects = [docrow_to_bbox(t) for t in target_toks]
+            im.draw_rects(rects, stroke="yellow", stroke_width=4, fill=None)
+
+        page_images.append(wandb.Image(im.annotated, caption="page " + str(pagenum)))
+
+        # get best matching score of any token in the training data
+    #match = doc.tokens[SINGLE_CLASS_PREDICTION].max()
+    #caption = (
+    #    f"{doc.slug} guessed:{predict_text} answer:{answer_text} match:{match:.2f}"
+    #)
+   # verdict = dollar_match(predict_text, answer_text)
+    wandb.log({"docs": page_images}) 
+    #return verdict, caption, page_images
 
 def log_pdf(doc, score, scores, predict_text, answer_text):
     fname = get_pdf_path(doc.slug)
@@ -105,8 +171,5 @@ def log_pdf(doc, score, scores, predict_text, answer_text):
     caption = (
         f"{doc.slug} guessed:{predict_text} answer:{answer_text} match:{match:.2f}"
     )
-    if dollar_match(predict_text, answer_text):
-        caption = "CORRECT " + caption
-    else:
-        caption = "INCORRECT " + caption
-    wandb.log({caption: page_images})
+    verdict = dollar_match(predict_text, answer_text)
+    return verdict, caption, page_images

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -101,8 +101,7 @@ class DocAccCallback(K.callbacks.Callback):
         # return the average accuracy across all fields
         # advertiser, contract_num, flight_from, flight_to, gross_amount
         # we may want to adjust the relative weighting of these in the future
-        total_acc = sum(v for v in acc_dict.values())
-        return total_acc / 5.0
+        return sum(acc_dict.values()) / len(acc_dict)
 
     def on_epoch_end(self, epoch, logs):
         if epoch >= self.config.epochs - 1:

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -129,7 +129,6 @@ class DocAccCallback(K.callbacks.Callback):
         acc_str = re.sub(r"\s+", " ", acc.to_string())
 
         print(f"This epoch {self.logname}: {acc_str}")
-        acc_dict = acc.to_dict()
 
         # convert field names for benchmark logging
         wandb.log(

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -126,16 +126,13 @@ class DocAccCallback(K.callbacks.Callback):
 
         # convert field names for benchmark logging
         wandb.log(
-            {
-                "amount": acc["gross_amount"],
-                "flight_to": acc["flight_to"],
-                "flight_from": acc["flight_from"],
-                "contractid": acc["contract_num"],
-                "advertiser": acc["advertiser"],
-            }
+            acc.rename(
+                {"gross_amount": "amount", "contract_num": "contractid"}
+            ).to_dict()
         )
+
         # compute average accuracy
-        wandb.log({"avg_acc": acc.mean()})
+        wandb.log({"avg_acc": acc.mean(), "epoch": epoch})
 
 
 def main(config):

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -141,7 +141,7 @@ class DocAccCallback(K.callbacks.Callback):
             }
         )
         # compute average accuracy
-        wandb.log({"avg_acc": self.mean_field_acc(acc_dict)})
+        wandb.log({"avg_acc": acc_dict.mean()})
 
 
 def main(config):

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -128,7 +128,6 @@ class DocAccCallback(K.callbacks.Callback):
             self.log_path / kind / f"{epoch:02d}",
         )
         acc_str = re.sub(r"\s+", " ", acc.to_string())
-        print("ACCURACY: ", acc)
         print(f"This epoch {self.logname}: {acc_str}")
 
         # convert field names for benchmark logging

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -79,12 +79,13 @@ def compute_accuracy(model, config, dataset, num_to_test, print_results, log_pat
             prefix = "✔️" if match else "❌"
             guessed = f'guessed "{predict_text}" with score {predict_score:.3f}'
             correction = "" if match else f', was actually "{answer_text}"'
-            doc_log["match"] = match
-
+            doc_log["match"].append(match)
             if print_results:
                 print(f"\t{prefix} {field}: {guessed}{correction}")
         if print_results and n_print > 0:
-            log_wandb_pdfs(doc, doc_log, all_scores)
+            log_wandb_pdfs(
+                doc, doc_log, all_scores
+            )  # TODO: get fields here more explicitly?
             n_print -= 1
     return pd.Series(accuracies) / n_docs
 
@@ -127,21 +128,21 @@ class DocAccCallback(K.callbacks.Callback):
             self.log_path / kind / f"{epoch:02d}",
         )
         acc_str = re.sub(r"\s+", " ", acc.to_string())
-
+        print("ACCURACY: ", acc)
         print(f"This epoch {self.logname}: {acc_str}")
 
         # convert field names for benchmark logging
         wandb.log(
             {
-                "amount": acc_dict["gross_amount"],
-                "flight_to": acc_dict["flight_to"],
-                "flight_from": acc_dict["flight_from"],
-                "contractid": acc_dict["contract_num"],
-                "advertiser": acc_dict["advertiser"],
+                "amount": acc["gross_amount"],
+                "flight_to": acc["flight_to"],
+                "flight_from": acc["flight_from"],
+                "contractid": acc["contract_num"],
+                "advertiser": acc["advertiser"],
             }
         )
         # compute average accuracy
-        wandb.log({"avg_acc": acc_dict.mean()})
+        wandb.log({"avg_acc": acc.mean()})
 
 
 def main(config):

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -55,9 +55,7 @@ def compute_accuracy(model, config, dataset, num_to_test, print_results, log_pat
             print(f"file_id:{slug}")
 
         # track all logging information for this document
-        doc_log = {}
-        for log_key in ["pred_text", "true_text", "score", "field", "match"]:
-            doc_log[log_key] = []
+        doc_log = defaultdict(list)
         for i, (field, answer_text) in enumerate(doc.label_values.items()):
             predict_text = predict_texts[i]
             predict_score = predict_scores[i]

--- a/deepform/train.py
+++ b/deepform/train.py
@@ -98,12 +98,6 @@ class DocAccCallback(K.callbacks.Callback):
         self.logname = logname
         self.log_path = LOG_DIR / "predictions" / run_timestamp
 
-    def mean_field_acc(self, acc_dict):
-        # return the average accuracy across all fields
-        # advertiser, contract_num, flight_from, flight_to, gross_amount
-        # we may want to adjust the relative weighting of these in the future
-        return sum(acc_dict.values()) / len(acc_dict)
-
     def on_epoch_end(self, epoch, logs):
         if epoch >= self.config.epochs - 1:
             # last epoch, sample from all docs and print inference results

--- a/deepform/util.py
+++ b/deepform/util.py
@@ -168,6 +168,7 @@ def wandb_bbox(t, score, class_id, pdf_page, min_height=10):
         "class_id": class_id,
         "domain": "pixel",
         "scores": {"score": score},
+        "box_caption": "%.3f" % score,
     }
     return box_data
 

--- a/deepform/util.py
+++ b/deepform/util.py
@@ -155,8 +155,8 @@ def wandb_bbox(t, score, class_id, pdf_page, min_height=10):
     dims = docrow_to_bbox(t, min_height)
 
     # reproject bounding box into pdf image
-    x0, y0 = pdf_page._reproject((dims["x0"], dims["y0"]))
-    x1, y1 = pdf_page._reproject((dims["x1"], dims["y1"]))
+    x0, y0 = pdf_page._reproject((dims.x0, dims.y0))
+    x1, y1 = pdf_page._reproject((dims.x1, dims.y1))
 
     box_data = {
         "position": {

--- a/deepform/util.py
+++ b/deepform/util.py
@@ -147,23 +147,33 @@ def docrow_to_bbox(t, min_height=10):
         dims["y0"] = min(dims["y1"] - Decimal(min_height), dims["y0"])
     return BoundingBox(**dims)
 
+
 def wandb_bbox(t, score, class_id, pdf_page, min_height=10):
-    """ Prototype logging bounding boxes to W&B. Currently W&B assumes a fixed
+    """Prototype logging bounding boxes to W&B. Currently W&B assumes a fixed
     single size for each image logged, so this requires resizing all logged documents
-    to see correct bounding boxes  """
+    to see correct bounding boxes"""
     dims = {k: Decimal(float(getattr(t, k))) for k in ["x0", "y0", "x1", "y1"]}
     if min_height:
         dims["y0"] = min(dims["y1"] - Decimal(min_height), dims["y0"])
 
-    # reproject bounding box into pdf image    
+    # reproject bounding box into pdf image
     x0, y0 = pdf_page._reproject((dims["x0"], dims["y0"]))
     x1, y1 = pdf_page._reproject((dims["x1"], dims["y1"]))
 
-    box_data = {"position" : { "minX" : float(x0), "minY" : float(y0), \
-               "maxX" : float(x1), "maxY": float(y1)}, \
-                "class_id" : class_id, "domain" : "pixel",  "scores" : {"score" : score}}
+    box_data = {
+        "position": {
+            "minX": float(x0),
+            "minY": float(y0),
+            "maxX": float(x1),
+            "maxY": float(y1),
+        },
+        "class_id": class_id,
+        "domain": "pixel",
+        "scores": {"score": score},
+    }
     return box_data
- 
+
+
 def config_desc(config):
     """A one-line text string describing the configuration of a run."""
     return (

--- a/deepform/util.py
+++ b/deepform/util.py
@@ -152,9 +152,7 @@ def wandb_bbox(t, score, class_id, pdf_page, min_height=10):
     """Prototype logging bounding boxes to W&B. Currently W&B assumes a fixed
     single size for each image logged, so this requires resizing all logged documents
     to see correct bounding boxes"""
-    dims = {k: Decimal(float(getattr(t, k))) for k in ["x0", "y0", "x1", "y1"]}
-    if min_height:
-        dims["y0"] = min(dims["y1"] - Decimal(min_height), dims["y0"])
+    dims = docrow_to_bbox(t, min_height)
 
     # reproject bounding box into pdf image
     x0, y0 = pdf_page._reproject((dims["x0"], dims["y0"]))

--- a/deepform/util.py
+++ b/deepform/util.py
@@ -147,7 +147,7 @@ def docrow_to_bbox(t, min_height=10):
         dims["y0"] = min(dims["y1"] - Decimal(min_height), dims["y0"])
     return BoundingBox(**dims)
 
-def wandb_bbox(t, score, class_id, pdf_page, w, h, min_height=10):
+def wandb_bbox(t, score, class_id, pdf_page, min_height=10):
     """ Prototype logging bounding boxes to W&B. Currently W&B assumes a fixed
     single size for each image logged, so this requires resizing all logged documents
     to see correct bounding boxes  """


### PR DESCRIPTION
A collection of minor changes mostly to clean up the logging to W&B and simplify benchmark comparison.
Very open to feedback/improvements, especially on any conventions, naming, and any useful logs I may have removed.

* biggest change: refactor to log all PDFs to one "Media" panel section instead of a separate section for each single doc. Logging for W&B-native bounding boxes is set up but not enabled--boxes won't show up correctly until we a) resize all logged documents to the same fixed size and/or b) make changes to the W&B CLI and/or c) do some further debugging. log_pdfs_with_wandb() is basically a clone of log_pdf() with this extension--now that it's stable/if we like it, we could a) remove log_pdfs() and/or b) take out all the references to logging W&B bounding boxes until we can get those to work. The pdfplumber native boxes are pretty great, though could probably be cleaned up/thresholded/organized further. I organized the colors to signify different classes, and green to signify the ground truth.
* second biggest change: add an "avg_acc" field to use as the main ranking for the benchmark, and rename fields for the benchmark slightly ("contract_num" => "contractid", "gross_amount" => "amount") so I don't have to mess with the very narrow columns for the leaderboard/keep trying to convince our main front-end person on this point :).

minor tail
* fixes a random seed for a deterministic train/val data split (also sets this to as a TF random seed for reproducibility, no strong attachment to this)
* removes references to WANDB_ENTITY, will require all users to login with their respective wandb accounts
* sets a different default WANDB_PROJECT, "deepform_v1"