### PR TITLE
Store docs as a python list instead of numpy ndarray to avoid slow initialization

### DIFF
--- a/deepform/train.py
+++ b/deepform/train.py
@@ -154,7 +154,7 @@ def main(config):
     all_documents = DocumentStore.open(index_file=TRAINING_INDEX, config=config)
 
     # split into validation and training sets
-    validation_set, training_set = all_documents.split(percent=config.val_split)
+    validation_set, training_set = all_documents.split(val_percent=config.val_split)
     print(f"Training on {len(training_set)}, validating on {len(validation_set)}")
 
     model = create_model(config)


### PR DESCRIPTION
I noticed that after configuration is printed when training, the script hangs for a good 30 minutes or so -- even when using the data cache to create documents. I tracked it down to:
```
docs = np.array(
    [slug_to_doc(slug, labels.loc[slug]) for slug in doc_index.index]
)
```

When the numpy array constructor is given objects with iterable functions like `__len__` and `__getitem__`, it traverses as many dimensions down as it can go (see more [here](https://stackoverflow.com/questions/38774922/prevent-numpy-from-creating-a-multidimensional-array)). In this case it means that every possible window from every `Document` is traversed, which has to create subarrays and pandas Series from the Document attributes.

I thought I could fix it using [this](https://stackoverflow.com/a/22290296/11954720) or [this](https://stackoverflow.com/a/51879900/11954720) trick, but they didn't work for some reason. Instead my PR turns `documents` into a normal list, since I didn't notice the numpy functionality being used anywhere.